### PR TITLE
[CICD] 빅뱅배포용 CICD 파이프라인 생성

### DIFF
--- a/.github/workflows/cicd-bigbang-dev.yml
+++ b/.github/workflows/cicd-bigbang-dev.yml
@@ -1,0 +1,59 @@
+name: React BigBang CI/CD - Dev V1
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment: dev
+
+    steps:
+    - name: Checkout source code
+      uses: actions/checkout@v3
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '20'
+
+    - name: Install pnpm
+      run: npm install -g pnpm
+
+    - name: Install dependencies
+      run: pnpm install
+
+    - name: Build with Vite (with env)
+      run: pnpm build
+      env:
+        VITE_API_URL: ${{ secrets.VITE_API_URL }}
+        VITE_BASE_URL: ${{ secrets.VITE_BASE_URL }}
+        VITE_KAKAO_AUTH_CLIENT_ID: ${{ secrets.VITE_KAKAO_AUTH_CLIENT_ID }}
+        VITE_KAKAO_AUTH_URL: ${{ secrets.VITE_KAKAO_AUTH_URL }}
+        VITE_PUBLIC_MSW: ${{ secrets.VITE_PUBLIC_MSW }}
+
+    - name: Decode GCP service account key
+      run: echo "${{ secrets.GCP_CICD_SSH_KEY }}" | base64 --decode > $HOME/gcp-key.json
+
+    - name: Authenticate to GCP
+      uses: google-github-actions/auth@v1
+      with:
+        credentials_json: ${{ secrets.GCP_CICD_SSH_KEY }}
+
+    - name: Setup gcloud CLI
+      uses: google-github-actions/setup-gcloud@v1
+      with:
+        project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+    - name: Deploy to GCS
+      run: |
+        gsutil -m rsync -r -d dist gs://${{ secrets.GCS_BUCKET_NAME }}
+        gsutil web set -m index.html -e index.html gs://${{ secrets.GCS_BUCKET_NAME }}
+
+    - name: Invalidate Cloud CDN cache
+      run: |
+        gcloud compute url-maps invalidate-cdn-cache ${{ secrets.GCP_URL_MAP_NAME }} \
+          --path "/*" \
+          --project=${{ secrets.GCP_PROJECT_ID }}


### PR DESCRIPTION
## 요약
- 프론트엔드(Vite 기반 React 앱)의 정적 파일을 GCS에 업로드
- 배포 후 Cloud CDN 캐시를 무효화하는 GitHub Actions CI/CD 파이프라인을 구축

## 주요 변경 사항
- dev / cicd/bigbang-temp 브랜치 push 시 자동 빌드 및 배포
- 환경변수 (VITE_*) 주입 후 Vite build 수행
- 서비스 계정 인증 → GCS 배포(rsync) → CDN invalidate 처리 자동화

## 기타
- cicd/bigbang-temp 브랜치 push 기준 정상 빌드 및 배포 확인
- 기존 캐시 삭제 포함하여 실시간 반영 완료됨 