### PR TITLE
[BugFix] 투표 중복 생성 오류 해결

### DIFF
--- a/src/features/make/components/voteCardPreviewModal.tsx
+++ b/src/features/make/components/voteCardPreviewModal.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 import { useCreateVoteMutation } from '@/api/services/vote/quries'
@@ -19,14 +20,21 @@ export const VoteCardPreviewModal = ({ groupId, content, image, closedAt, anonym
   const { closeModal } = useModalStore()
   const { mutate } = useCreateVoteMutation()
 
+  const submit = useRef<boolean>(false)
+
+  console.log(submit.current)
+
   const onSubmit = () => {
+    if (submit.current) return
+    submit.current = true
+
     mutate(
       { groupId, content, imageUrl: '', closedAt, anonymous },
       {
         onSuccess: () => {
           toast('투표를 등록했습니다.')
           navigation('/research')
-          closeModal()
+          // closeModal()
         },
       },
     )

--- a/src/features/make/components/voteCardPreviewModal.tsx
+++ b/src/features/make/components/voteCardPreviewModal.tsx
@@ -34,7 +34,7 @@ export const VoteCardPreviewModal = ({ groupId, content, image, closedAt, anonym
         onSuccess: () => {
           toast('투표를 등록했습니다.')
           navigation('/research')
-          // closeModal()
+          closeModal()
         },
       },
     )

--- a/src/features/make/components/voteCardPreviewModal.tsx
+++ b/src/features/make/components/voteCardPreviewModal.tsx
@@ -22,8 +22,6 @@ export const VoteCardPreviewModal = ({ groupId, content, image, closedAt, anonym
 
   const submit = useRef<boolean>(false)
 
-  console.log(submit.current)
-
   const onSubmit = () => {
     if (submit.current) return
     submit.current = true


### PR DESCRIPTION
## 📌 관련 이슈

- #77 

## 🔥 작업 개요

- 투표 중복 생성 오류 해결

## 🛠️ 작업 상세

- 투표 중복 생성 방지를 위한 `submit` ref추가로 처음 요청만 전송되고, 이후 요청은 거절됨
- 요청이 성공하면 자동으로 페이지 이동, 이후 모달이 열리면 다시 mounte되기 때문에 ref 초기화 필요 없음

## 🧪 테스트

- [ ] 직접 테스트 완료
- [ ] UI 확인 완료
- [ ] 에러 로그 확인 완료

## 💬 기타 논의 사항

- 없음

### ✅ 셀프 체크리스트

- [ ] PR 제목은 형식에 맞게 작성했나요?
- [ ] 이슈는 close 됬나요?
- [ ] Reviewers, Label을 등록 했나요?
- [ ] 불필요한 코드는 제거 했나요?
