### PR TITLE
[CICD] PR 생성 시 리뷰어 자동 등록

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,8 @@
+addReviewers: true
+numberOfReviewers: 2
+reviewers:
+  - gunhee0421
+  - yunabyte
+  - Mason-P-ark
+
+addAssignees: false

--- a/.github/workflows/pr-auto-reviewer.yml
+++ b/.github/workflows/pr-auto-reviewer.yml
@@ -1,0 +1,22 @@
+name: Auto assign reviewer
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+
+
+permissions:
+  pull-requests: write
+
+
+jobs:
+  assign-reviewer:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Assign reviewer
+        uses: kentaro-m/auto-assign-action@v1.2.1
+        with:
+          configuration-path: ".github/auto_assign.yml"


### PR DESCRIPTION
## 개요
PR 생성 시 자동으로 Reviewer를 지정하는 기능을 추가했습니다.
리뷰어 지정 없이 PR 하셔도 자동으로 리뷰어가 지정됩니다.

## 변경 내용
- `.github/workflows/pr-auto-reviewer.yml` 추가
  - 대상 브랜치: `main`, `dev`
  - 워크플로우 실행 시 `.github/auto_assign.yml`을 참조하여 자동 지정 수행
- `.github/auto_assign.yml` 추가
  - reviewers: `gunhee0421`, `yunabyte`, `Mason-P-ark`

## 적용 배경
- 리뷰어를 매번 수동으로 지정하는 번거로움을 줄이기 위해 자동화를 도입했습니다.
- PR 담당자 및 승인자 설정을 명확히 하여 협업 효율을 높이고자 합니다.

## 참고
- 작성자는 GitHub 정책상 리뷰어로 인정되지 않음 (무시됨)
- assignees는 본인 수동 설정 필요