### PR TITLE
[Bugfix] 미리보기 타이머 오류 수정

### DIFF
--- a/src/components/card/voteCardPreview.tsx
+++ b/src/components/card/voteCardPreview.tsx
@@ -67,7 +67,7 @@ export const VoteCardPreview = ({ content, image, closedAt, anonymous }: Props) 
             <CardTitle className="font-pyeojinGothic text-2xl">익명</CardTitle>
           </div>
         )}
-        <span className="text-xs pr-2 min-w-20">{formatTime(closedAt)}</span>
+        <span className="text-xs pr-2 min-w-20">{formatTime(closedAt, false)}</span>
       </CardHeader>
       <CardContent className="flex justify-center items-center h-full overflow-y-auto break-words">
         <p className="text-2xl whitespace-pre-line break-all">{content || '내용을 입력하세요.'}</p>

--- a/src/lib/formatTime.ts
+++ b/src/lib/formatTime.ts
@@ -1,10 +1,8 @@
 import { toKstISOString } from './toKSTISOString'
 
-export default function formatTime(timeStamp: string): string {
-  const KSTtime = toKstISOString(timeStamp)
-
+export default function formatTime(timeStamp: string, KST: boolean = true): string {
   const now = Date.now()
-  const date = new Date(KSTtime)
+  const date = KST ? new Date(toKstISOString(timeStamp)) : new Date(timeStamp)
   const diff = now - date.getTime()
 
   const year = date.getFullYear()


### PR DESCRIPTION
## 📌 관련 이슈

## 🔥 작업 개요

- 미리보기 타이머 +9시간 오류 해결

## 🛠️ 작업 상세

- 한국시간이던 데이터에 +9가 발생해서 원하던 시간과의 괴리가 발생함

## 🧪 테스트

- [ ] 직접 테스트 완료
- [ ] UI 확인 완료
- [ ] 에러 로그 확인 완료

## 💬 기타 논의 사항

- 없음

### ✅ 셀프 체크리스트

- [x] PR 제목은 형식에 맞게 작성했나요?
- [x] 이슈는 close 됬나요?
- [x] Reviewers, Label을 등록 했나요?
- [x] 불필요한 코드는 제거 했나요?
