### PR TITLE
feat: 스크롤 유지 추가

### DIFF
--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -53,6 +53,17 @@ export const AppLayout = () => {
     setTab(location.pathname)
   }, [setTab, navigation, setAccessToken, setIsLogin, accessToken, location.pathname])
 
+  useEffect(() => {
+    const main = document.getElementById('main-content')
+    if (!main) return
+
+    const preserveScrollRoutes = ['/research']
+
+    if (!preserveScrollRoutes.includes(location.pathname)) {
+      main.scrollTop = 0
+    }
+  }, [location.pathname])
+
   return (
     <div>
       <Header />

--- a/src/components/card/voteCard.tsx
+++ b/src/components/card/voteCard.tsx
@@ -52,8 +52,12 @@ export const VoteCard = (props: Partial<Vote>) => {
         {isImageValid && (
           <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-black/40 to-transparent rounded-[3.125rem]" />
         )}
-
-        <div className="min-h-[90%] flex items-end justify-center px-2">
+        <div
+          className={cn(
+            'min-h-[90%] flex items-end justify-center px-2',
+            !isImageValid && 'items-center',
+          )}
+        >
           <p
             data-testid="vote-content"
             className="sm:text-xl whitespace-pre-line break-all text-center py-2 z-30"

--- a/src/components/card/voteCardPreview.tsx
+++ b/src/components/card/voteCardPreview.tsx
@@ -48,7 +48,7 @@ export const VoteCardPreview = ({ content, image, closedAt, anonymous }: Props) 
     <Card
       className={cn(
         `p-0 w-[80%] h-[30rem] max-h-[75%] border-none pointer-events-auto text-white rounded-[3.125rem] shadow-card text-shadow-lg`,
-        !isImageValid && 'bg-gradient-to-b from-[#FFe29A] via-[#FFD265] to-[#FAC549]',
+        !isImageValid && 'bg-primary-gradient-down',
       )}
       style={
         isImageValid

--- a/src/components/card/voteEndCard.tsx
+++ b/src/components/card/voteEndCard.tsx
@@ -7,7 +7,7 @@ export const VoteEndCard = () => {
 
   return (
     <Card
-      className={`px-4 py-9 w-[90%] md:w-[70%] h-[30rem] max-h-[75%] flex justify-center bg-primary text-white rounded-[3.125rem] shadow-card relative`}
+      className={`px-4 py-9 w-[90%] h-[30rem] max-h-[75%] flex justify-center bg-primary-gradient-down text-white rounded-[3.125rem] shadow-card relative`}
     >
       <CardHeader className="flex flex-col justify-between w-full items-center px-0 text-black">
         <div className="flex flex-row gap-1 ">

--- a/src/components/card/voteNoMoreCard.tsx
+++ b/src/components/card/voteNoMoreCard.tsx
@@ -9,7 +9,7 @@ export const VoteNoMoreCard = () => {
 
   return (
     <Card
-      className={`px-4 py-9 w-[90%] md:w-[70%] h-[30rem] max-h-[75%] flex justify-center bg-primary text-white rounded-[3.125rem] shadow-card relative`}
+      className={`px-4 py-9 w-[90%] h-[30rem] max-h-[75%] flex justify-center bg-primary-gradient-down text-white rounded-[3.125rem] shadow-card relative`}
     >
       <CardHeader className="flex flex-col justify-between w-full items-center px-0 text-black">
         <div className="flex flex-row gap-1 ">

--- a/src/components/loading/loadingCard.tsx
+++ b/src/components/loading/loadingCard.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent } from '../ui/card'
 export const LoadingCard = () => {
   return (
     <Card
-      className={`px-4 py-9 w-[90%] md:w-[70%] h-[30rem] max-h-[75%] bg-primary text-white rounded-[3.125rem] shadow-card`}
+      className={`px-4 py-9 w-[90%] h-[30rem] max-h-[75%] bg-primary-gradient-down text-white rounded-[3.125rem] shadow-card`}
     >
       <CardContent className="flex flex-col justify-center items-center h-full overflow-y-auto text-2xl text-center font-semibold gap-10">
         <div>

--- a/src/features/make/components/makeVoteForm.tsx
+++ b/src/features/make/components/makeVoteForm.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
-import { useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { ChevronRight } from 'lucide-react'
 import { useVoteDetailInfo } from '@/api/services/vote/queries'
@@ -26,6 +26,7 @@ import { VoteSchema, voteSchema } from '../lib/makeVoteSchema'
 
 export const MakeVoteForm = () => {
   const { voteId } = useParams()
+  const router = useNavigate()
 
   const { selectedId, setId } = useGroupStore()
   const { openModal } = useModalStore()
@@ -34,7 +35,7 @@ export const MakeVoteForm = () => {
   const [minDateTime, setMinDateTime] = useState('')
   const [maxDateTime, setMaxDateTime] = useState('')
 
-  const { data: editData } = useVoteDetailInfo(voteId ?? '')
+  const { data: editData, isError } = useVoteDetailInfo(voteId ?? '')
 
   const form = useForm<VoteSchema>({
     resolver: zodResolver(voteSchema),
@@ -106,6 +107,12 @@ export const MakeVoteForm = () => {
       })
     }
   }, [editData, form])
+
+  useEffect(() => {
+    if (isError) {
+      router('/research')
+    }
+  }, [isError, router])
 
   return (
     <div className="w-full px-5 pt-3 flex items-center justify-center">

--- a/src/features/research/components/researchList.tsx
+++ b/src/features/research/components/researchList.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { motion } from 'framer-motion'
 import {
   useCreateVotesInfinityQuery,
@@ -7,6 +8,7 @@ import { VoteList } from '@/components/list/voteList'
 import { Label } from '@/components/ui/label'
 import { trackEvent } from '@/lib/trackEvent'
 import { useGroupStore } from '@/stores/groupStore'
+import { useScrollStore } from '@/stores/scrollStore'
 import { useResearchTabStore } from '../stores/researchTapStore'
 
 export const ResearchList = () => {
@@ -35,6 +37,40 @@ export const ResearchList = () => {
       page: location.pathname,
     })
   }
+
+  const { setScroll, getScroll } = useScrollStore()
+
+  useEffect(() => {
+    const main = document.getElementById('main-content')
+
+    const handleScroll = () => {
+      if (!main) return
+      const y = main.scrollTop
+      clearTimeout((handleScroll as any).timer)
+      ;(handleScroll as any).timer = setTimeout(() => {
+        setScroll('research', y)
+      }, 100)
+    }
+
+    main?.addEventListener('scroll', handleScroll)
+    return () => {
+      clearTimeout((handleScroll as any).timer)
+      main?.removeEventListener('scroll', handleScroll)
+    }
+  }, [setScroll])
+
+  useEffect(() => {
+    if (!data) return
+
+    const timer = setTimeout(() => {
+      const main = document.getElementById('main-content')
+      if (main && main.scrollHeight > main.clientHeight) {
+        main.scrollTo(0, getScroll('research') || 0)
+      }
+    }, 0)
+
+    return () => clearTimeout(timer)
+  }, [data, getScroll])
 
   const tabs = ['참여한 투표', '내가 만든 투표']
 

--- a/src/features/research/pages/researchPage.tsx
+++ b/src/features/research/pages/researchPage.tsx
@@ -3,7 +3,7 @@ import { ResearchList } from '../components/researchList'
 
 const ResearchPage = () => {
   return (
-    <article className="min-h-full overflow-y-auto">
+    <article className="min-h-full">
       <div className="pl-4 py-3">
         <GroupDropDown />
       </div>

--- a/src/features/user/components/userCard.tsx
+++ b/src/features/user/components/userCard.tsx
@@ -76,7 +76,7 @@ export const UserCard = () => {
 
   return (
     <Card className="relative px-5 py-6 w-full bg-primary-gradient-down-right text-black rounded-4xl shadow-md border-none h-40 gap-[2.5rem]">
-      <CardHeader className="px-4 relative h-24">
+      <CardHeader className="px-4 relative h-full">
         {isEditing ? (
           <Form {...form}>
             <form

--- a/src/mocks/handlers/researchHandlers.ts
+++ b/src/mocks/handlers/researchHandlers.ts
@@ -9,6 +9,15 @@ export const researchHandlers = [
       return HttpResponse.json({ message: 'NO_TOKEN', data: null }, { status: 401 })
     }
 
+    if (voteId === '0') {
+      return HttpResponse.json(
+        {
+          message: 'ERROR',
+          data: null,
+        },
+        { status: 404 },
+      )
+    }
     if (voteId) {
       return HttpResponse.json(
         {

--- a/src/stores/scrollStore.ts
+++ b/src/stores/scrollStore.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+type ScrollStore = {
+  scrollMap: Record<string, number>
+  // eslint-disable-next-line no-unused-vars
+  setScroll: (path: string, y: number) => void
+  // eslint-disable-next-line no-unused-vars
+  getScroll: (path: string) => number
+}
+
+export const useScrollStore = create(
+  persist<ScrollStore>(
+    (set, get) => ({
+      scrollMap: {},
+      setScroll: (path, y) =>
+        set((state) => ({
+          scrollMap: {
+            ...state.scrollMap,
+            [path]: y,
+          },
+        })),
+      getScroll: (path) => get().scrollMap[path] ?? 0,
+    }),
+    {
+      name: 'scroll-storage',
+    },
+  ),
+)


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #156

## 🔥 작업 개요

- 투표 결과 스크롤 페이지 이동 시 초기화 개선

## 🛠️ 작업 상세

- 투표 결과 스크롤 페이지 재진입 이전 스크롤 위치로 자동 이동
- 일부 카드 디자인 변경 추가
- 투표카드에 이미지가 없을 경우, 텍스트 가운데 정렬

## 🧪 테스트

- [ ] 직접 테스트 완료
- [x] UI 확인 완료
- [x] 에러 로그 확인 완료

## 💬 기타 논의 사항

- 없음

### ✅ 셀프 체크리스트

- [x] PR 제목은 형식에 맞게 작성했나요?
- [x] 이슈는 close 됬나요?
- [x] Reviewers, Label을 등록 했나요?
- [x] 불필요한 코드는 제거 했나요?
