### PR TITLE
feat: 모바일 브라우저 댓글 전송 분기 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,12 @@
       })(window, document, 'script', 'dataLayer', 'GTM-WM3FLNHP')
     </script>
     <!-- End Google Tag Manager -->
+    <meta property="og:title" content="MOA(모두의 아젠다)" />
+    <meta property="og:description" content="스와이프를 통해 다양한 투표에 참여해보세요!" />
+    <meta property="og:image" content="/images/home.png" />
+    <meta property="og:url" content="https://moagenda.com" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="MOA(모두의 아젠다)" />
   </head>
   <body>
     <!-- Google Tag Manager (noscript) -->

--- a/src/components/card/groupCard.tsx
+++ b/src/components/card/groupCard.tsx
@@ -107,17 +107,13 @@ const GroupDotsItem = ({
       >
         떠나기
       </button>
-      {isMine && (
-        <>
-          <hr className="text-gray-300" />
-          <button
-            onClick={() => router(`/group/${groupId}`)}
-            className="rounded-b-2xl w-full px-3 py-2 text-sm hover:bg-gray-100 text-left cursor-pointer"
-          >
-            그룹 관리
-          </button>
-        </>
-      )}
+      <hr className="text-gray-300" />
+      <button
+        onClick={() => router(`/group/${groupId}`)}
+        className="rounded-b-2xl w-full px-3 py-2 text-sm hover:bg-gray-100 text-left cursor-pointer"
+      >
+        {isMine ? '그룹 상세 보기' : '그룹 관리 '}
+      </button>
     </div>
   )
 }

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -11,16 +11,16 @@ export const Slider = () => {
     <AnimatePresence>
       {isOpen && (
         <>
-          <motion.div
-            className="fixed top-0 h-full z-60 flex items-center justify-center bg-black/50 max-w-[450px] w-full overflow-hidden backdrop-blur-xs"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            onClick={close}
-          />
           <div className="fixed top-0 z-60 h-full w-full max-w-[450px] flex justify-end overflow-hidden">
             <motion.div
-              className="w-[80%] max-w-[315px] h-full bg-white shadow-lg py-4 overflow-y-auto flex flex-col"
+              className="fixed top-0 h-full bg-black/50 max-w-[450px] w-full overflow-hidden backdrop-blur-xs"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              onClick={close}
+            />
+            <motion.div
+              className="w-[80%] max-w-[315px] z-10 h-full bg-white shadow-lg py-4 overflow-y-auto flex flex-col hide-scrollbar "
               initial={{ x: '100%' }}
               animate={{ x: 0 }}
               exit={{ x: '100%' }}

--- a/src/features/group/components/groupMember.tsx
+++ b/src/features/group/components/groupMember.tsx
@@ -17,7 +17,7 @@ export const GroupMember = () => {
   }, [data, search])
 
   return (
-    <div>
+    <div className="min-h-[80svh]">
       <h1 className="text-2xl font-bold mb-4">멤버 목록</h1>
       <MemberSearchBar search={search} onChange={setSearch} />
       <MemberList members={filteredMembers} isLoading={!data} />

--- a/src/features/group/components/groupReport.tsx
+++ b/src/features/group/components/groupReport.tsx
@@ -1,16 +1,24 @@
 import { useNavigate, useParams } from 'react-router-dom'
+import { Group } from '@/api/services/group/model'
 import { Button } from '@/components/ui/button'
+import { ableManage } from '@/utils/authority'
 
-export const GroupReport = () => {
+interface Props {
+  group: Group
+}
+
+export const GroupReport = ({ group }: Props) => {
   const { groupId } = useParams()
 
   const route = useNavigate()
   return (
     <div className="">
       <h1 className="text-2xl font-bold mb-4">그룹 리포트</h1>
-      <Button className="h-full w-full bg-white text-lg py-3 shadow-md cursor-pointer">
-        그룹 내 리포트 확인하기
-      </Button>
+      {ableManage(group.role) && (
+        <Button className="h-full w-full bg-white text-lg py-3 shadow-md cursor-pointer">
+          그룹 내 리포트 확인하기
+        </Button>
+      )}
       <Button
         onClick={() => route(`/group/${groupId}/votes`)}
         className="mt-4 h-full w-full bg-white text-lg py-3 shadow-md cursor-pointer"

--- a/src/features/group/pages/manageGroupPage.tsx
+++ b/src/features/group/pages/manageGroupPage.tsx
@@ -1,13 +1,22 @@
+import { useParams } from 'react-router-dom'
+import { useGroupQuery } from '@/api/services/group/queries'
 import { GroupMember } from '../components/groupMember'
 import { GroupReport } from '../components/groupReport'
 import { UpdateGroupForm } from '../components/updateGroupForm'
 
 const ManageGroupPage = () => {
+  const { groupId } = useParams()
+  const { data: group } = useGroupQuery(Number(groupId))
+
+  if (!group) {
+    return <></>
+  }
+
   return (
     <article className="px-5 py-5 min-h-full">
-      <UpdateGroupForm />
+      <UpdateGroupForm group={group} />
       <div className="w-[450px] my-3 bg-gray h-[0.625rem] transform -translate-x-5" />
-      <GroupReport />
+      <GroupReport group={group} />
       <div className="w-[450px] my-3 bg-gray h-[0.625rem] transform -translate-x-5" />
       <GroupMember />
     </article>

--- a/src/features/research/components/commentInput.tsx
+++ b/src/features/research/components/commentInput.tsx
@@ -60,7 +60,9 @@ export const CommentInput = () => {
                   placeholder="댓글을 입력해주세요."
                   {...field}
                   onKeyDown={(e) => {
-                    if (e.key === 'Enter' && !e.shiftKey) {
+                    const isMobile = /Mobi|Android|iPhone|iPad/i.test(navigator.userAgent)
+
+                    if (!isMobile && e.key === 'Enter' && !e.shiftKey) {
                       e.preventDefault()
                       form.handleSubmit(onSubmit)()
                     }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -7,3 +7,11 @@
     height: calc(100svh - 8.5rem);
   }
 }
+
+.hide-scrollbar {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.hide-scrollbar::-webkit-scrollbar {
+  display: none;
+}

--- a/src/utils/authority.ts
+++ b/src/utils/authority.ts
@@ -1,0 +1,8 @@
+import { GroupRole } from '@/api/services/group/model'
+
+export const ableManage = (role: GroupRole | undefined) => {
+  return role === 'MANAGER' || role === 'OWNER'
+}
+export const ableOwner = (role: GroupRole | undefined) => {
+  return role === 'OWNER'
+}


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #187

## 🔥 작업 개요

- 모바일 enter 시 전송 제거
- 알림 회색배경 클릭으로 닫기 버그 픽스
- meta데이터 추가
- 그룹 관리 페이지를 상세페이지로 권한분기

## 🛠️ 작업 상세

- index.html에 기본og 메타데이터 추가
- 브라우저만 enter시 자동 전송, 모바일은 전송되지 않도록 개선
- 알림 회색배경 클릭으로 닫기 추가
- 그룹 상세페이지에 모두 접근이 가능하고, 권한에 따른 기능 제한 설정

## 🧪 테스트

- [ ] 직접 테스트 완료
- [x] UI 확인 완료
- [x] 에러 로그 확인 완료

## 💬 기타 논의 사항

- 없음

### ✅ 셀프 체크리스트

- [x] PR 제목은 형식에 맞게 작성했나요?
- [x] 이슈는 close 됬나요?
- [x] Reviewers, Label을 등록 했나요?
- [x] 불필요한 코드는 제거 했나요?
