### PR TITLE
feat: 그룹 리포트 페이지 개발

### DIFF
--- a/src/api/services/group/model.ts
+++ b/src/api/services/group/model.ts
@@ -98,3 +98,16 @@ export type GroupVoteListResponse = PageNation<'votes', ParticipatedVote[]> & {
   groupId: number
   groupName: string
 }
+
+export type GroupAnalysisResponse = {
+  groupId: number
+  groupName: string
+  weekStartDate: string
+  analysis: {
+    summaryText: string
+  }
+  participationStats: {
+    participated: number
+    notParticipated: number
+  }
+}

--- a/src/api/services/group/queries.ts
+++ b/src/api/services/group/queries.ts
@@ -6,6 +6,7 @@ import {
 } from '@tanstack/react-query'
 import { AxiosError } from 'axios'
 import {
+  GroupAnalysisResponse,
   GroupRoleChangeRequest,
   GroupVoteListResponse,
   MyGroupList,
@@ -151,5 +152,13 @@ export const useGroupVotesInfiniteQuery = (groupId: number, size: number = 10) =
     getNextPageParam: (lastPage) => (lastPage?.hasNext ? lastPage.nextCursor : undefined),
     staleTime: 1000 * 60 * 15,
     initialPageParam: undefined,
+  })
+}
+// 그룹 내 리포트 조회
+export const useGroupAnalysisQuery = (groupId: number) => {
+  return useSuspenseQuery<GroupAnalysisResponse, AxiosError>({
+    queryKey: ['groupAnalysis', groupId],
+    queryFn: () => groupService.getGroupReports(groupId),
+    staleTime: 1000 * 60 * 60 * 24 * 6,
   })
 }

--- a/src/api/services/group/service.ts
+++ b/src/api/services/group/service.ts
@@ -3,6 +3,7 @@ import {
   CreateGroupData,
   CreateGroupPayload,
   Group,
+  GroupAnalysisResponse,
   GroupMemberDeleteResponse,
   GroupMembersResponse,
   GroupRoleChangeRequest,
@@ -97,6 +98,11 @@ export const groupService = {
     const response = await authAxiosInstance.get(
       `/api/v1/groups/${groupId}/votes?${params.toString()}`,
     )
+    return response.data.data
+  },
+  // Get: 그룹 내 리포트 조회
+  async getGroupReports(groupId: number): Promise<GroupAnalysisResponse> {
+    const response = await authAxiosInstance.get(`/api/v1/groups/${groupId}/analysis`)
     return response.data.data
   },
 }

--- a/src/api/services/vote/queries.ts
+++ b/src/api/services/vote/queries.ts
@@ -1,6 +1,5 @@
 import {
   useMutation,
-  useQuery,
   useQueryClient,
   useSuspenseInfiniteQuery,
   useSuspenseQuery,
@@ -109,10 +108,9 @@ export const useVoteDetailResults = (voteId: string) => {
 }
 // 투표 실패 사유 조회
 export const useVoteReportReasons = (voteId: string) => {
-  return useQuery<VoteReportReason>({
+  return useSuspenseQuery<VoteReportReason>({
     queryKey: ['voteReportReasons', voteId],
     queryFn: () => voteService.getVoteFailReason(voteId),
-    enabled: !!voteId,
   })
 }
 // 투표 수정
@@ -139,15 +137,10 @@ export const useDeleteVoteMutation = (voteId: string) => {
   })
 }
 // Top3 투표 조회
-export const useTop3VotesQuery = (
-  groupId: number,
-  type: TopVoteDay = 'daily',
-  enabled: boolean = true,
-) => {
-  return useQuery({
+export const useTop3VotesQuery = (groupId: number, type: TopVoteDay = 'daily') => {
+  return useSuspenseQuery({
     queryKey: ['top3Votes', groupId, type],
     queryFn: () => voteService.getTop3Votes(groupId, type),
-    enabled,
     staleTime: 1000 * 60 * 60 * 23, // 23h: 매일 오전 9시 재요청
   })
 }

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -17,6 +17,7 @@ export const GroupVotesPage = React.lazy(() => import('@/features/group/pages/gr
 export const UserPage = React.lazy(() => import('@/features/user/pages/userPage'))
 export const AuthCallback = React.lazy(() => import('@/features/login/pages/authCallback'))
 export const NotFoundPage = React.lazy(() => import('@/app/NotFound'))
+export const ReportPage = React.lazy(() => import('@/features/group/pages/reportPage'))
 
 export const router = createBrowserRouter([
   {
@@ -62,6 +63,10 @@ export const router = createBrowserRouter([
       {
         path: '/group/:groupId/votes',
         element: <GroupVotesPage />,
+      },
+      {
+        path: '/group/:groupId/report',
+        element: <ReportPage />,
       },
     ],
   },

--- a/src/components/card/groupCard.tsx
+++ b/src/components/card/groupCard.tsx
@@ -72,11 +72,19 @@ export const GroupCard = (group: Partial<Group>) => {
       </CardHeader>
       <CardContent className="flex flex-col flex-grow justify-between h-full">
         <p className="font-medium mb-7">{group.description}</p>
-        <pre className="font-medium flex items-center text-sm">
+        <pre
+          onClick={(e) => {
+            e.stopPropagation()
+          }}
+          className="font-medium flex items-center text-sm cursor-default"
+        >
           초대코드:<span className="font-semibold">{group.inviteCode}</span>
           <button
             type="button"
-            onClick={handleCopy}
+            onClick={(e) => {
+              handleCopy()
+              e.stopPropagation()
+            }}
             className="hover:text-primary ml-2 transition cursor-pointer"
           >
             {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}

--- a/src/components/chart/pieChart.tsx
+++ b/src/components/chart/pieChart.tsx
@@ -1,0 +1,70 @@
+interface PieSegment {
+  name: string
+  value: number
+  color: string
+}
+
+interface SvgPieChartProps {
+  data: PieSegment[]
+  size?: number
+  radius?: number
+}
+
+export const PieChart = ({ data, size = 200, radius = 90 }: SvgPieChartProps) => {
+  const total = data.reduce((sum, d) => sum + d.value, 0)
+  const center = size / 2
+  let cumulativeAngle = 0
+
+  const getCoordinates = (angle: number, customRadius = radius) => {
+    const radian = (angle - 90) * (Math.PI / 180)
+    const x = center + customRadius * Math.cos(radian)
+    const y = center + customRadius * Math.sin(radian)
+    return { x, y }
+  }
+
+  const segments = data.map((segment) => {
+    const valuePercent = segment.value / total
+    const startAngle = cumulativeAngle
+    const endAngle = cumulativeAngle + valuePercent * 360
+    const midAngle = (startAngle + endAngle) / 2
+    cumulativeAngle = endAngle
+
+    const largeArcFlag = endAngle - startAngle > 180 ? 1 : 0
+    const start = getCoordinates(startAngle)
+    const end = getCoordinates(endAngle)
+    const label = getCoordinates(midAngle, radius * 0.6)
+
+    const d = [
+      `M ${center} ${center}`,
+      `L ${start.x} ${start.y}`,
+      `A ${radius} ${radius} 0 ${largeArcFlag} 1 ${end.x} ${end.y}`,
+      'Z',
+    ].join(' ')
+
+    return (
+      <g key={segment.name}>
+        <path d={d} fill={segment.color} stroke="white" strokeWidth="0" />
+        <text
+          x={label.x}
+          y={label.y}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fontSize="12"
+          fontWeight="bold"
+          fill="#000"
+        >
+          {segment.name}
+          <tspan x={label.x} dy="1.2em">
+            {Math.round(valuePercent * 100)}%
+          </tspan>
+        </text>
+      </g>
+    )
+  })
+
+  return (
+    <svg width={size} height={size}>
+      {segments}
+    </svg>
+  )
+}

--- a/src/components/list/researchList.tsx
+++ b/src/components/list/researchList.tsx
@@ -1,11 +1,9 @@
 import { Suspense } from 'react'
-import { ErrorBoundary } from 'react-error-boundary'
 import { motion } from 'framer-motion'
 import {
   useCreateVotesInfinityQuery,
   useParticipatedVotesInfinityQuery,
 } from '@/api/services/vote/queries'
-import NotFoundPage from '@/app/NotFound'
 import { VoteList } from '@/components/list/voteList'
 import { Label } from '@/components/ui/label'
 import { trackEvent } from '@/lib/trackEvent'
@@ -63,11 +61,9 @@ export const ResearchList = () => {
           </div>
         ))}
       </div>
-      <ErrorBoundary fallbackRender={() => <NotFoundPage />}>
-        <Suspense fallback={<LoadingPage />}>
-          <VoteList data={data} fetchNextPage={fetchNextPage} hasNextPage={hasNextPage} />
-        </Suspense>
-      </ErrorBoundary>
+      <Suspense fallback={<LoadingPage />}>
+        <VoteList data={data} fetchNextPage={fetchNextPage} hasNextPage={hasNextPage} />
+      </Suspense>
     </section>
   )
 }

--- a/src/components/list/topList.tsx
+++ b/src/components/list/topList.tsx
@@ -1,15 +1,13 @@
 import { useTop3VotesQuery } from '@/api/services/vote/queries'
 import { VoteItem } from '@/components/item/voteItem'
 import { Label } from '@/components/ui/label'
-import { useGroupStore } from '@/stores/groupStore'
-import { useUserStore } from '@/stores/userStore'
 import { formatDateTimeDetail } from '@/utils/time'
 
-export const TopList = () => {
-  const { isLogin } = useUserStore()
-  const { selectedId } = useGroupStore()
-  const { data } = useTop3VotesQuery(selectedId, undefined, isLogin)
+interface Props {
+  data: ReturnType<typeof useTop3VotesQuery>['data']
+}
 
+export const TopList = ({ data }: Props) => {
   const { from, to } = getKSTDateRange()
 
   return (

--- a/src/features/group/components/ReportContent.tsx
+++ b/src/features/group/components/ReportContent.tsx
@@ -1,0 +1,49 @@
+import { useGroupAnalysisQuery } from '@/api/services/group/queries'
+import { useTop3VotesQuery } from '@/api/services/vote/queries'
+import { PieChart } from '@/components/chart/pieChart'
+import { VoteItem } from '@/components/item/voteItem'
+
+interface Props {
+  data: ReturnType<typeof useGroupAnalysisQuery>['data']
+}
+
+export const ReportContentChart = ({ data }: Props) => {
+  return (
+    <div className="px-5">
+      <h1 className="text-xl font-bold mb-4">{data.groupName}</h1>
+      <div>
+        <h2 className="text-lg font-medium mb-2">참여율</h2>
+        <div className="flex items-center justify-center">
+          <PieChart
+            data={[
+              { name: '참여', value: data.participationStats.participated, color: '#3AC98C' },
+              { name: '미참여', value: data.participationStats.notParticipated, color: '#FFD1CF' },
+            ]}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+export const ReportContentVotes = ({ groupId }: { groupId: number }) => {
+  const { data } = useTop3VotesQuery(groupId, 'weekly')
+
+  return (
+    <div className="px-5">
+      <h2 className="text-lg font-medium mb-2">Top3</h2>
+      <ul className="flex flex-col gap-4 pt-4 pb-4 px-4">
+        {data.topVotes.map((vote, idx) => (
+          <VoteItem key={vote.voteId} rank={idx + 1} {...vote} />
+        ))}
+      </ul>
+    </div>
+  )
+}
+export const ReportContentAnalysis = ({ data }: Props) => {
+  return (
+    <div className="px-5">
+      <h2 className="text-lg font-medium mb-2">요약</h2>
+      <p className="px-12">{data.analysis.summaryText}</p>
+    </div>
+  )
+}

--- a/src/features/group/components/groupReport.tsx
+++ b/src/features/group/components/groupReport.tsx
@@ -14,7 +14,10 @@ export const GroupReport = ({ group }: Props) => {
   return (
     <div className="px-5">
       <h1 className="text-2xl font-bold mb-4">그룹 리포트</h1>
-      <Button className="h-full w-full bg-white text-lg py-3 shadow-md cursor-pointer">
+      <Button
+        onClick={() => route(`/group/${groupId}/report`)}
+        className="h-full w-full bg-white text-lg py-3 shadow-md cursor-pointer"
+      >
         그룹 내 리포트 확인하기
       </Button>
       {ableManage(group.role) && (

--- a/src/features/group/pages/groupVotesPage.tsx
+++ b/src/features/group/pages/groupVotesPage.tsx
@@ -1,18 +1,14 @@
 import { Suspense } from 'react'
-import { ErrorBoundary } from 'react-error-boundary'
 import { useParams } from 'react-router-dom'
 import { useGroupQuery, useGroupVotesInfiniteQuery } from '@/api/services/group/queries'
-import NotFoundPage from '@/app/NotFound'
 import { VoteList } from '@/components/list/voteList'
 import { LoadingPage } from '@/components/loading/loadingPage'
 
 const GroupVotesPage = () => {
   return (
-    <ErrorBoundary fallbackRender={() => <NotFoundPage />}>
-      <Suspense fallback={<LoadingPage />}>
-        <GroupVotesPageContent />
-      </Suspense>
-    </ErrorBoundary>
+    <Suspense fallback={<LoadingPage />}>
+      <GroupVotesPageContent />
+    </Suspense>
   )
 }
 export default GroupVotesPage

--- a/src/features/group/pages/manageGroupPage.tsx
+++ b/src/features/group/pages/manageGroupPage.tsx
@@ -1,8 +1,6 @@
 import { Suspense } from 'react'
-import { ErrorBoundary } from 'react-error-boundary'
 import { useParams } from 'react-router-dom'
 import { useGroupQuery } from '@/api/services/group/queries'
-import NotFoundPage from '@/app/NotFound'
 import { LoadingPage } from '@/components/loading/loadingPage'
 import { GroupMember } from '../components/groupMember'
 import { GroupReport } from '../components/groupReport'
@@ -10,11 +8,9 @@ import { UpdateGroupForm } from '../components/updateGroupForm'
 
 const ManageGroupPage = () => {
   return (
-    <ErrorBoundary fallbackRender={() => <NotFoundPage />}>
-      <Suspense fallback={<LoadingPage />}>
-        <ManageGroupPageContent />
-      </Suspense>
-    </ErrorBoundary>
+    <Suspense fallback={<LoadingPage />}>
+      <ManageGroupPageContent />
+    </Suspense>
   )
 }
 

--- a/src/features/group/pages/reportPage.tsx
+++ b/src/features/group/pages/reportPage.tsx
@@ -1,0 +1,35 @@
+import { Suspense } from 'react'
+import { useParams } from 'react-router-dom'
+import { useGroupAnalysisQuery } from '@/api/services/group/queries'
+import { LoadingPage } from '@/components/loading/loadingPage'
+import {
+  ReportContentAnalysis,
+  ReportContentChart,
+  ReportContentVotes,
+} from '../components/ReportContent'
+
+const ReportPage = () => {
+  return (
+    <Suspense fallback={<LoadingPage />}>
+      <ReportPageContent />
+    </Suspense>
+  )
+}
+
+export default ReportPage
+
+const ReportPageContent = () => {
+  const { groupId } = useParams()
+
+  const { data } = useGroupAnalysisQuery(parseInt(groupId!))
+
+  return (
+    <article className="py-5 min-h-full">
+      <ReportContentChart data={data} />
+      <div className="w-full max-w-[450px] my-3 bg-line h-[0.625rem]" />
+      <ReportContentVotes groupId={parseInt(groupId!)} />
+      <div className="w-full max-w-[450px] my-3 bg-line h-[0.625rem]" />
+      <ReportContentAnalysis data={data} />
+    </article>
+  )
+}

--- a/src/features/home/pages/homePage.tsx
+++ b/src/features/home/pages/homePage.tsx
@@ -1,9 +1,7 @@
 import { Suspense, useEffect } from 'react'
-import { ErrorBoundary } from 'react-error-boundary'
 import { FaQuestion } from 'react-icons/fa'
 import { useUserInfoQuery } from '@/api/services/user/queries'
 import { useInfiniteVotesQuery } from '@/api/services/vote/queries'
-import NotFoundPage from '@/app/NotFound'
 import { GroupDropDown } from '@/components/dropdown/groupDropDown'
 import { LoadingCard } from '@/components/loading/loadingCard'
 import { NoVoteAvailAbleModal } from '@/components/modal/noVoteAvailableModal'
@@ -17,17 +15,15 @@ import { useVoteCardStore } from '../stores/voteCardStore'
 
 const HomePage = () => {
   return (
-    <ErrorBoundary fallbackRender={() => <NotFoundPage />}>
-      <Suspense
-        fallback={
-          <div className="flex screen-minus-header-nav justify-center items-center">
-            <LoadingCard />
-          </div>
-        }
-      >
-        <HomePageContent />
-      </Suspense>
-    </ErrorBoundary>
+    <Suspense
+      fallback={
+        <div className="flex screen-minus-header-nav justify-center items-center">
+          <LoadingCard />
+        </div>
+      }
+    >
+      <HomePageContent />
+    </Suspense>
   )
 }
 

--- a/src/features/make/pages/makePage.tsx
+++ b/src/features/make/pages/makePage.tsx
@@ -1,17 +1,13 @@
 import { Suspense } from 'react'
-import { ErrorBoundary } from 'react-error-boundary'
-import NotFoundPage from '@/app/NotFound'
 import { GroupDropDown } from '@/components/dropdown/groupDropDown'
 import { LoadingPage } from '@/components/loading/loadingPage'
 import { MakeVoteForm } from '../components/makeVoteForm'
 
 const MakePage = () => {
   return (
-    <ErrorBoundary fallbackRender={() => <NotFoundPage />}>
-      <Suspense fallback={<LoadingPage />}>
-        <MakePageContent />
-      </Suspense>
-    </ErrorBoundary>
+    <Suspense fallback={<LoadingPage />}>
+      <MakePageContent />
+    </Suspense>
   )
 }
 

--- a/src/features/make/pages/updatePage.tsx
+++ b/src/features/make/pages/updatePage.tsx
@@ -1,17 +1,13 @@
 import { Suspense } from 'react'
-import { ErrorBoundary } from 'react-error-boundary'
-import NotFoundPage from '@/app/NotFound'
 import { GroupDropDown } from '@/components/dropdown/groupDropDown'
 import { LoadingPage } from '@/components/loading/loadingPage'
 import { UpdateVoteForm } from '../components/updateVoteForm'
 
 const UpdatePage = () => {
   return (
-    <ErrorBoundary fallbackRender={() => <NotFoundPage />}>
-      <Suspense fallback={<LoadingPage />}>
-        <UpdatePageContent />
-      </Suspense>
-    </ErrorBoundary>
+    <Suspense fallback={<LoadingPage />}>
+      <UpdatePageContent />
+    </Suspense>
   )
 }
 

--- a/src/features/research/pages/researchDetail.Page.tsx
+++ b/src/features/research/pages/researchDetail.Page.tsx
@@ -1,8 +1,6 @@
 import { Suspense } from 'react'
-import { ErrorBoundary } from 'react-error-boundary'
 import { useParams } from 'react-router-dom'
 import { useVoteDetailInfo, useVoteDetailResults } from '@/api/services/vote/queries'
-import NotFoundPage from '@/app/NotFound'
 import { CommentList } from '@/components/list/commentList'
 import { LoadingPage } from '@/components/loading/loadingPage'
 import { CommentInput } from '../components/commentInput'
@@ -10,11 +8,9 @@ import ResearchDetailInfo from '../components/researchDetailInfo'
 
 const ResearchDetailPage = () => {
   return (
-    <ErrorBoundary fallbackRender={() => <NotFoundPage />}>
-      <Suspense fallback={<LoadingPage />}>
-        <ResearchDetailPageContent />
-      </Suspense>
-    </ErrorBoundary>
+    <Suspense fallback={<LoadingPage />}>
+      <ResearchDetailPageContent />
+    </Suspense>
   )
 }
 

--- a/src/features/research/pages/researchPage.tsx
+++ b/src/features/research/pages/researchPage.tsx
@@ -1,30 +1,32 @@
 import { Suspense } from 'react'
-import { ErrorBoundary } from 'react-error-boundary'
-import NotFoundPage from '@/app/NotFound'
+// import { useParams } from 'react-router-dom'
+// import { useTop3VotesQuery } from '@/api/services/vote/queries'
 import { GroupDropDown } from '@/components/dropdown/groupDropDown'
 import { ResearchList } from '@/components/list/researchList'
 import { LoadingPage } from '@/components/loading/loadingPage'
 
 const ResearchPage = () => {
   return (
-    <ErrorBoundary fallbackRender={() => <NotFoundPage />}>
-      <Suspense fallback={<LoadingPage />}>
-        <ResearchPageContent />
-      </Suspense>
-    </ErrorBoundary>
+    <Suspense fallback={<LoadingPage />}>
+      <ResearchPageContent />
+    </Suspense>
   )
 }
 
 export default ResearchPage
 
 const ResearchPageContent = () => {
+  // const { groupId } = useParams()
+
+  // const { data } = useTop3VotesQuery(parseInt(groupId!), undefined)
+
   return (
     <article className="min-h-full">
       <div className="pl-4 py-3">
         <GroupDropDown />
       </div>
       {/* <div className="bg-gray w-full h-[0.625rem] mt-1" />
-      <TopList /> */}
+      <TopList data={data} /> */}
       <div className="bg-line w-full h-[0.625rem] mt-1" />
       <ResearchList />
     </article>

--- a/src/features/user/pages/userPage.tsx
+++ b/src/features/user/pages/userPage.tsx
@@ -1,6 +1,4 @@
 import { Suspense, useRef } from 'react'
-import { ErrorBoundary } from 'react-error-boundary'
-import NotFoundPage from '@/app/NotFound'
 import { UserGroupList } from '@/components/list/userGroupList'
 import { LoadingPage } from '@/components/loading/loadingPage'
 import { UserCard } from '@/features/user/components/userCard'
@@ -8,11 +6,9 @@ import { UserFeedbackWidget } from '../components/userFeedbackWidget'
 
 const UserPage = () => {
   return (
-    <ErrorBoundary fallbackRender={() => <NotFoundPage />}>
-      <Suspense fallback={<LoadingPage />}>
-        <UserPageContent />
-      </Suspense>
-    </ErrorBoundary>
+    <Suspense fallback={<LoadingPage />}>
+      <UserPageContent />
+    </Suspense>
   )
 }
 

--- a/src/mocks/handlers/groupHandlers.ts
+++ b/src/mocks/handlers/groupHandlers.ts
@@ -322,4 +322,23 @@ export const groupHandlers = [
       { status: 200 },
     )
   }),
+  http.get('/api/v1/groups/:groupId/analysis', ({ params }) => {
+    const { groupId } = params
+
+    return HttpResponse.json({
+      message: 'SUCCESS',
+      data: {
+        groupId: parseInt(groupId as string, 10),
+        groupName: 'KTB',
+        weekStartDate: '2025-01-01',
+        analysis: {
+          summaryText: '이번주 KTB 그룹의 활동은 활발합니다. 많은 투표와 의견 교환이 있었습니다.',
+        },
+        participationStats: {
+          participated: 31.7,
+          notParticipated: 68.3,
+        },
+      },
+    })
+  }),
 ]


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #219

## 🔥 작업 개요

- 그룹 리포트 페이지 개발
- 그룹 리포트 api 쿼리 추가
- 중복된 ErrorBoundary 제거
- 마이페이지 초대코드 복사 시 페이지 이동 버그 픽스

## 🛠️ 작업 상세

- 그룹 리포트 페이지 컴포넌트 개발
- 그룹 리포트 쿼리 `useGroupAnalysisQuery` 추가
- 최상단 ErrorBoundary가 존재하기 때문에, 하위 중복되는 ErrorBoundary 제거
- 마이페이지 초대코드 클릭 시 이벤트 전파 차단으로 페이지 이동 제거

## 🧪 테스트

- [ ] 직접 테스트 완료
- [x] UI 확인 완료
- [x] 에러 로그 확인 완료

## 💬 기타 논의 사항

- 없음

### ✅ 셀프 체크리스트

- [x] PR 제목은 형식에 맞게 작성했나요?
- [x] 이슈는 close 됬나요?
- [x] Reviewers, Label을 등록 했나요?
- [x] 불필요한 코드는 제거 했나요?
